### PR TITLE
Check if ASCComponent is still valid before accessing AbilitySpecPtr.…

### DIFF
--- a/Source/GASAttachEditor/Private/GASAttachEditor/SGASReflectorNodeBase.cpp
+++ b/Source/GASAttachEditor/Private/GASAttachEditor/SGASReflectorNodeBase.cpp
@@ -387,7 +387,7 @@ bool FGASAbilitieNode::HasValidWidgetAssetData() const
 
 FString FGASAbilitieNode::GetWidgetAssetData() const
 {
-	if (GAAbilitieNode != Node_Abilitie)
+	if (!ASComponent.IsValid() || GAAbilitieNode != Node_Abilitie)
 	{
 		return FString();
 	}


### PR DESCRIPTION
…Ability

It fixes crashes caused by a dangling pointer in AbilitySpecPtr.Ability.